### PR TITLE
Add support for explicit method implementations for handlers

### DIFF
--- a/src/Hellang.MessageBus/HelperExtensions.cs
+++ b/src/Hellang.MessageBus/HelperExtensions.cs
@@ -68,8 +68,18 @@ namespace Hellang.MessageBus
         /// <returns>The handle method for the specified message type or null.</returns>
         public static MethodInfo GetHandleMethodFor(this Type type, Type messageType)
         {
-            return type.GetMethods(BindingFlags.Public | BindingFlags.Instance)
-                       .SingleOrDefault(method => method.IsHandleMethodFor(messageType));
+            var m= type.GetMethods(BindingFlags.Public | BindingFlags.Instance).SingleOrDefault(method => method.IsHandleMethodFor(messageType));
+            if (m == null)
+            {
+                // look for explicit method implementation
+                var handlerType = typeof(IHandle<>).MakeGenericType(messageType);
+                if (handlerType.IsAssignableFrom(type))
+                {
+                    m = handlerType.GetMethods().SingleOrDefault(method => method.IsHandleMethodFor(messageType));
+                }
+            }
+
+            return m;
         }
 
         /// <summary>

--- a/test/Hellang.MessageBus.Tests/MessageBusTests.cs
+++ b/test/Hellang.MessageBus.Tests/MessageBusTests.cs
@@ -162,5 +162,18 @@ namespace Hellang.MessageBus.Tests
             Assert.That(target.HandledMessageTypes.Contains(typeof(TestMessage)));
             Assert.That(target.HandledMessageTypes.Contains(typeof(DerivedTestMessage)));
         }
+      
+        [Test]
+        public void MessagesAreHandledByExplicitSubscriber() {
+            var bus = new DirectDispatchMessageBus();
+
+            var target = new ExplicitSubscriber();
+            bus.Subscribe(target);
+
+            bus.Publish<TestMessage>();
+
+            Assert.That(target.MessageHandleCount, Is.EqualTo(1));
+        }
     }
+     
 }

--- a/test/Hellang.MessageBus.Tests/TestObjects/Subscribers/ExplicitSubscriber.cs
+++ b/test/Hellang.MessageBus.Tests/TestObjects/Subscribers/ExplicitSubscriber.cs
@@ -1,0 +1,14 @@
+﻿using Hellang.MessageBus.Tests.TestObjects.Messages;
+
+namespace Hellang.MessageBus.Tests.TestObjects.Subscribers {
+    public class ExplicitSubscriber : IHandle<TestMessage>
+    {
+        public int MessageHandleCount { get; set; }
+
+        void IHandle<TestMessage>.Handle(TestMessage message)
+        {
+            MessageHandleCount++;
+        }
+         
+    }
+}


### PR DESCRIPTION
Nice library.  light weight.  but out of  the gate my explicit IHandler implementations didnt work.

Here's a change to add support.  you can now have:  

```C#
        void IHandle<TestMessage>.Handle(TestMessage message)
        {
            MessageHandleCount++;
        }
```